### PR TITLE
Cast bank_id to string instead of integer in order to keep leading zeros

### DIFF
--- a/Adyen/Api.php
+++ b/Adyen/Api.php
@@ -59,7 +59,7 @@ class Api
         $banks = array();
         $xml = new \SimpleXMLElement($response->getContent());
         foreach($xml->bank as $bank) {
-            $banks[(int) $bank->bank_id] = (string) $bank->bank_name;
+            $banks[(string) $bank->bank_id] = (string) $bank->bank_name;
         }
 
         return $banks;


### PR DESCRIPTION
The issuers list for my production environment is broken, because the bank_id's coming from the adyen api are padded with leading zero's. For example, Rabobank is '0021'. By casting it to integers, the leading zero's are truncated and when going to adyen after selecting a bank, Adyen shows an error "invalid bank id". This should fix that.
