### PR TITLE
php compatibilty issue

### DIFF
--- a/Adyen/Api.php
+++ b/Adyen/Api.php
@@ -90,11 +90,11 @@ class Api
         $parameters = array();
         $parameters['paymentAmount']     = $amount * 100;
         $parameters['currencyCode']      = $currency;
-        $parameters['shipBeforeDate']    = (new \DateTime('+1 hour'))->format('Y-m-d');
+        $parameters['shipBeforeDate']    = date('Y-m-d', strtotime('+1 hour'));
         $parameters['merchantReference'] = $id;
         $parameters['skinCode']          = $this->skinCode;
         $parameters['merchantAccount']   = $this->merchantAccount;
-        $parameters['sessionValidity']   = (new \DateTime('+1 hour'))->format(DATE_ATOM);
+        $parameters['sessionValidity']   = date(DATE_ATOM, strtotime('+1 hour'));
         $parameters['skipSelection']     = 'true';
         $parameters['brandCode']         = 'ideal';
         $parameters['idealIssuerId']     = $bank;
@@ -124,11 +124,11 @@ class Api
         $parameters = array();
         $parameters['paymentAmount']       = $amount * 100;
         $parameters['currencyCode']        = $currency;
-        $parameters['shipBeforeDate']      = (new \DateTime('+1 hour'))->format('Y-m-d');
+        $parameters['shipBeforeDate']      = date('Y-m-d', strtotime('+1 hour'));
         $parameters['merchantReference']   = $id;
         $parameters['skinCode']            = $this->skinCode;
         $parameters['merchantAccount']     = $this->merchantAccount;
-        $parameters['sessionValidity']     = (new \DateTime('+1 hour'))->format(DATE_ATOM);
+        $parameters['sessionValidity']     = date(DATE_ATOM, strtotime('+1 hour'));
         $parameters['shopperReference']    = '1';
         $parameters['recurringContract']   = null;
         $parameters['allowedMethods']      = null;


### PR DESCRIPTION
The anonymous object creation syntax can only be used on PHP 5.4 or higher.
Since the version constraint in composer is >=5.3.2 this will not work under PHP 5.3 versions.

It's just a simple fix with date/strtotime functions.
