### PR TITLE
Updated composer.json to allow higher versions of Buzz.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.0",
         "jms/payment-core-bundle": "~1.0",
-        "kriswallsmith/buzz": ">=0.7,<=0.10"
+        "kriswallsmith/buzz": ">=0.7"
     },
     "autoload": {
         "psr-0": { "Ruudk\\Payment\\AdyenBundle": "" }


### PR DESCRIPTION
Hi,

I just updated the composer.json to allow a higher version of kriswallsmith/buzz.
I tested it locally with a test-account from Adyen and it seems to work fine (positive and negative feedback from Adyen payments).

Please - if possible - merge this PR and tag a release for packagist.

Thank you!
